### PR TITLE
chore: add sameSite attribute to the http only cookie

### DIFF
--- a/authx/routers/social.py
+++ b/authx/routers/social.py
@@ -117,7 +117,7 @@ def get_router(
                 secure=not debug,
                 httponly=True,
                 max_age=access_expiration,
-                sameSite="lax"
+                samesite="lax"
             )
             response.set_cookie(
                 key=refresh_cookie_name,
@@ -125,7 +125,7 @@ def get_router(
                 secure=not debug,
                 httponly=True,
                 max_age=refresh_expiration,
-                sameSite="lax"
+                samesite="lax"
             )
             return response
         except SocialException as e:

--- a/authx/routers/social.py
+++ b/authx/routers/social.py
@@ -117,6 +117,7 @@ def get_router(
                 secure=not debug,
                 httponly=True,
                 max_age=access_expiration,
+                sameSite="lax"
             )
             response.set_cookie(
                 key=refresh_cookie_name,
@@ -124,6 +125,7 @@ def get_router(
                 secure=not debug,
                 httponly=True,
                 max_age=refresh_expiration,
+                sameSite="lax"
             )
             return response
         except SocialException as e:


### PR DESCRIPTION
## what's new?
- Added `sameSite` as `lax` attribute to the http only cookie

## Sources
See: https://web.dev/samesite-cookies-explained/